### PR TITLE
Skip chmod in WSL deploy script

### DIFF
--- a/deploy_ereader.sh
+++ b/deploy_ereader.sh
@@ -451,7 +451,7 @@ then
 fi
 
 # Set proper permissions (Unix-specific)
-if "${PLATFORM}" != "WSL"; then
+if [ "${PLATFORM}" != "WSL" ]; then
   echo -e "${GREEN}Setting permissions...${NC}"
   if command -v chmod >/dev/null 2>&1; then
     if ! chmod -R 755 "$DEVICE_PLUGIN_DIR/ereader.koplugin"; then

--- a/deploy_ereader.sh
+++ b/deploy_ereader.sh
@@ -451,13 +451,15 @@ then
 fi
 
 # Set proper permissions (Unix-specific)
-echo -e "${GREEN}Setting permissions...${NC}"
-if command -v chmod >/dev/null 2>&1; then
-  if ! chmod -R 755 "$DEVICE_PLUGIN_DIR/ereader.koplugin"; then
-    echo -e "${YELLOW}Warning: Failed to set permissions on plugin directory${NC}"
+if "${PLATFORM}" != "WSL"; then
+  echo -e "${GREEN}Setting permissions...${NC}"
+  if command -v chmod >/dev/null 2>&1; then
+    if ! chmod -R 755 "$DEVICE_PLUGIN_DIR/ereader.koplugin"; then
+      echo -e "${YELLOW}Warning: Failed to set permissions on plugin directory${NC}"
+    fi
+  else
+    echo -e "${YELLOW}Warning: chmod not available, skipping permission setting${NC}"
   fi
-else
-  echo -e "${YELLOW}Warning: chmod not available, skipping permission setting${NC}"
 fi
 
 # Cross-platform device ejection

--- a/plugins/ereader.koplugin/main.lua
+++ b/plugins/ereader.koplugin/main.lua
@@ -901,10 +901,10 @@ function Ereader:archiveArticle(article)
     UIManager:close(info)
     
     if success then
-        UIManager:show(InfoMessage:new{
-            text = (did_enqueue and _("Article will be archived in next sync")) or _("Article archived"),
-            timeout = 2,
-        })
+        -- UIManager:show(InfoMessage:new{
+        --   text = (did_enqueue and _("Article will be archived in next sync")) or _("Article archived"),
+        --    timeout = 2,
+        -- })
         -- Refresh the article list
         self:showArticles()
     else

--- a/plugins/ereader.koplugin/readerereader.lua
+++ b/plugins/ereader.koplugin/readerereader.lua
@@ -352,10 +352,10 @@ function ReaderEreader:onArchiveArticle()
         UIManager:close(info)
         
         if success then
-            UIManager:show(InfoMessage:new{
-                text = (did_enqueue and "Article will be archived in next sync") or "Article archived",
-                timeout = 2,
-            })
+            -- UIManager:show(InfoMessage:new{
+            --    text = (did_enqueue and "Article will be archived in next sync") or "Article archived",
+            --    timeout = 2,
+            -- })
             -- Return to articles list
             self:onBackToArticles()
         else


### PR DESCRIPTION
WSL can't change permissions on a drvfs mount and the step is unnecessary. This patch skips that step when install is from WSL.